### PR TITLE
[WIP]READMEにDB設計を記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Things you may want to cover:
 |------|----|-------|
 |email|string|null: false, add_index :users, :email, unique: true|
 |password|string|null: false|
-|username|string|null: false, add_index :users, :username|
+|name|string|null: false, add_index :users, :username|
 ### Association
 - has_many :messages
 - has_many :users_groups
@@ -38,7 +38,7 @@ Things you may want to cover:
 ## groupテーブル
 |Column|Type|Options|
 |------|----|-------|
-|groupname|string|null: false|
+|name|string|null: false|
 ### Association
 - has_many :messages
 - has_many :users_groups

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Things you may want to cover:
 ## messageテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text|
 |image|string|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -22,3 +22,44 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+# Chatspace DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false, add_index :users, :email, unique: true|
+|password|string|null: false|
+|username|string|null: false, add_index :users, :username|
+### Association
+- has_many :messages
+- has_many :users_groups
+- has_many :groups, through: :users_groups
+
+## groupテーブル
+|Column|Type|Options|
+|------|----|-------|
+|groupname|string|null: false|
+### Association
+- has_many :messages
+- has_many :users_groups
+- has_many  :users,  through:  :users_groups
+
+## users_groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## messageテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group


### PR DESCRIPTION
# What
ChatspaceのDB設計をREADME.mdに追加した。

# why
Chatspaceに必要な情報をどのようにデータベースで管理するかを決めるため。
- 登録ユーザーのメールアドレスが重複しないよう、usersテーブルのemailに一意性制約をかける設計にした。
- グループにユーザーを追加する際のユーザー名検索を高速化するために、usersテーブルのusernameにインデックスを貼る設計にした。