### PR TITLE
Final-adjustment

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -15,8 +15,8 @@ $(function(){
           <div class="lower-message">
             <p class="lower-message__content">
               ${message.content}
-              <img src=${message.image} />
             </p>
+              <img src=${message.image} />
           </div>
         </div>`
       return html;
@@ -62,7 +62,7 @@ $(function(){
       $('.form__submit').attr('disabled', false);
     })
     .fail(function(){
-      alert('error');
+      alert('メッセージを入力して下さい');
       $('.form__submit').attr('disabled', false);
     })
   })
@@ -82,7 +82,9 @@ $(function(){
           insertHTML = buildHTML(message);
           $('.messages').append(insertHTML);
         })
-        $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+        if (messages.length != 0){
+          $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+        };
       })
       .fail(function() {
         alert('自動更新に失敗しました');

--- a/app/assets/stylesheets/_messages-chat-main.scss
+++ b/app/assets/stylesheets/_messages-chat-main.scss
@@ -36,11 +36,13 @@
     overflow: scroll;
     background-color: #FAFAFA;
     box-sizing: border-box;
-    padding: 46px 40px 0;
+    padding: 46px 40px;
     height: calc(100vh - 100px - 90px);
     .message {
+      padding-bottom: 40px;
       .upper-message {
         display: flex;
+        margin-bottom: 10px;
         &__user-name {
           color: #434a54;
           font-size: 16px;
@@ -53,11 +55,10 @@
         }
       }
       .lower-message {
-        margin-top: 10px;
         &__content {
           color: #434a54;
           font-size: 14px;
-          margin-bottom: 40px;
+          margin-bottom: 10px;
         }
       }
     }
@@ -102,4 +103,9 @@
       }
     }
   }
+}
+
+::-webkit-scrollbar {
+  display: none;
+  -webkit-appearance: none;
 }

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ module ChatSpace
       g.helper false
       g.test_framework false
       config.i18n.default_locale = :ja
+      config.time_zone = 'Tokyo'
     end
   end
 end


### PR DESCRIPTION
最終調整として以下の修正をした
・メッセージビューの崩れの修正
・メッセージ部分のスクロールバーを非表示化
・メッセージ投稿時間を日本時間に修正
・自動更新の際に新しいメッセージがない場合、最新メッセージへのスクロールをしないように修正